### PR TITLE
Event subscription docs update

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     fast_blank (1.0.0)
     fastimage (2.0.1)
       addressable (~> 2)
-    ffi (1.9.17)
+    ffi (1.15.4)
     haml (4.0.7)
       tilt
     hamster (3.0.0)
@@ -126,4 +126,4 @@ RUBY VERSION
    ruby 2.3.3p222
 
 BUNDLED WITH
-   1.15.4
+   1.17.3

--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -12,7 +12,7 @@ curl "https://api.handshq.com/v1/authentication" \
 > In all subsequent examples make sure to replace `[api_token]` with your API key.
 
 HandsHQ uses API keys to allow access to the API. You can find your API key in the API tab of your settings page
-[here.](https://app.handshq.com/settings/api)
+[here.](https://app.handshq.com/settings/api_configuration)
 
 
 HandsHQ expects for the API key to be included in all API requests to the server in a header that looks like the following:
@@ -33,4 +33,3 @@ If you need to test that you have a valid API key use the following endpoint:
 ### Response
 
 Successful authentication with return a `200` response, otherwise a `401` will be returned when supplied with an invalid API key.
-

--- a/source/includes/_fields.md
+++ b/source/includes/_fields.md
@@ -91,7 +91,7 @@ You retrieve an ordered list of fields which you are currently using for your pr
 
 ### Fields information
 - `label` - Label on project forms and end documents, e.g. 'Address 1'
-- `requred` - Whether or not the field is required for project creation.
+- `required` - Whether or not the field is required for project creation.
 - `value` - The default value that will be immediately be applied to fields.
 - `data_type` - How the value of the field will be stored and the type of field provided to the user for editing. Will one of the following:
   - `string`

--- a/source/includes/_projects.md
+++ b/source/includes/_projects.md
@@ -35,8 +35,8 @@ This endpoint allows you to create a project for the company who is registered w
 Parameter | Format | Required | Description
 --------- | ------ | -------- | -----------
 name | String | Yes | Name of your project, used for document titles, names of PDF documents etc.
-start_date | DateTime | No | To denote when your project starts, used in conjunciton with `end_time` to denote whether project is still active.
-end_date | DateTime | No | To denote when your project starts, used in conjunciton with `start_time` to denote whether project is still active.
+start_date | DateTime | No | To denote when your project starts, used in conjunction with `end_time` to denote whether project is still active.
+end_date | DateTime | No | To denote when your project ends, used in conjunction with `start_time` to denote whether project is still active.
 reference | String | No | Your internal reference for a project e.g. 'RA01'
 
 In order to set further details we need a reference to which fields you would like to set a value for, these can differ for each company if you are using custom templates. You can find these references with our `fields` endpoint.

--- a/source/includes/_projects.md
+++ b/source/includes/_projects.md
@@ -3,7 +3,7 @@
 ## Creating a project
 
 ```shell
-curl http://api.handshq.com/v1/projects \
+curl https://api.handshq.com/v1/projects \
   -H "Accept: application/json" \
   -H "Authorization: bearer [api_token]" \
   --request POST \

--- a/source/includes/event_subscriptions.md
+++ b/source/includes/event_subscriptions.md
@@ -1,0 +1,238 @@
+# Event Subscriptions
+
+## Creating an event subscription
+
+```shell
+curl https://api.handshq.com/v1/event_subscriptions \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: bearer [api_token]" \
+  --request POST \
+  -d "[json_payload]"
+```
+
+> Example Event Subscription creation payload.
+
+```json
+  {
+    "event_subscription": {
+      "external_url": "https://some.external_location.com/webhooks",
+      "event_type": "version_pdf_created"
+    }
+  }
+
+```
+
+This endpoint allows you to be notified of certain events. Those currently supported are:
+
+- `version_pdf_created` - this is fired after we have generated and stored a PDF, which is now ready to be downloaded.
+<aside class="notice">
+  Please note that the `version_pdf_created` event is scoped to look for subscriptions which were created by the same division that the project belongs to.
+</aside>
+
+### HTTP Request
+
+`POST https://api.handshq.com/v1/event_subscriptions`
+
+### Allowed Event Subscription Parameters
+
+Parameter | Format | Required | Description
+--------- | ------ | -------- | -----------
+external_url | String | Yes | A valid URL which we will send a `POST` request to when the event occurs (see below for samples of these)
+event_type | String | Yes | The name of the event you wish to be notified about, allowed values: [`version_pdf_created`]
+
+
+### Response
+
+Successful requests will return a json payload of the project that was created and a `201` status code.
+
+> 201
+
+```json
+{
+  "data": {
+    "id": "123",
+    "type": "event_subscription",
+    "relationships": {
+      "subscriber": {
+        "data": {
+          "id": "321",
+          "type": "subscriber"
+        }
+      }
+    },
+    "links": {
+        "related": "https://some.external_location.com/webhooks"
+    }
+  }
+}
+```
+
+## Removing an event subscription
+
+```shell
+curl https://api.handshq.com/v1/event_subscriptions/[id] \
+  -H "Accept: application/json" \
+  -H "Authorization: bearer [api_token]" \
+  --request DELETE
+```
+
+If you no longer wish for an event subscription to be active, then this endpoint can delete an already created one.
+
+### HTTP Request
+
+`DELETE https://api.handshq.com/v1/event_subscriptions/[id]`
+
+### Allowed Event Subscription Parameters
+
+Parameter | Format | Required | Description
+--------- | ------ | -------- | -----------
+id | String | Yes | The id of the event subscription you wish to destroy
+
+
+### Response
+
+Successful requests will return a `204` status code, and thusly no accompanying body.
+
+# Event Notifications
+
+Each Event Subscription will send a `POST` request to the location set out within it's own `external_url` that has been provided once the event occurs.
+
+These will be in a `JSON` format and still in-keeping with the `JSON:API` specification.
+
+The body of an event subscription will vary depending on the type of event being subscribed to.
+
+## Version PDF Created
+
+```json
+{
+  "data": {
+    "id": "2",
+    "type": "version_pdf",
+    "attributes": {
+      "created_at": "2021-11-05T11:30:32.742+00:00",
+      "file_size": 32540
+    },
+    "relationships": {
+      "version": {
+        "data": {
+          "id": "50",
+          "type": "version"
+        }
+      }
+    },
+    "links": {
+      "content": "https://exampleRemoteStorage.com/123.pdf"
+    }
+  },
+  "included": [
+    {
+      "id": "50",
+      "type": "version",
+      "attributes": {
+        "is_fully_signed": false,
+        "pdf_filename": "my-lovely-project.pdf",
+        "display_number": 0,
+        "created_at": "2021-11-05T11:29:33.222+00:00"
+      },
+      "relationships": {
+        "history": {
+          "data": {
+            "id": "50",
+            "type": "history"
+          }
+        },
+        "version_pdf": {
+          "data": {
+            "id": "2",
+            "type": "version_pdf"
+          }
+        }
+      }
+    },
+    {
+      "id": "50",
+      "type": "history",
+      "attributes": {
+        "reason": "Jane D. created the project",
+        "createdAt": "2021-11-05T11:29:32.955+00:00",
+        "displayNumber": 0,
+        "eventType": "generic"
+      },
+      "relationships": {
+        "project": {
+          "data": {
+            "id": "19",
+            "type": "project"
+          }
+        },
+        "message": {
+          "data": null
+        }
+      }
+    },
+    {
+      "id": "19",
+      "type": "project",
+      "attributes": {
+        "name": "My lovely project",
+        "reference": "ref1",
+        "start_date": null,
+        "end_date": null
+      },
+      "relationships": {
+        "fields": {
+          "data": [
+            {
+              "id": "261",
+              "type": "field"
+            },
+            {
+              "id": "265",
+              "type": "field"
+            },
+          ]
+        },
+        "latest_reviewed_version": {
+          "data": null
+        },
+        "user": {
+          "data": {
+            "id": "5",
+            "type": "user"
+          }
+        }
+      },
+      "links": {
+        "app_url": "https://localhost:3000/projects/19"
+      }
+    }
+  ]
+}
+```
+### Data:
+
+  - The attributes of PDF record
+    - Link to the URL of where the PDF is hosted
+
+### Included Resources:
+
+  - The `Project` that it was derived from.
+    - Link to the project within HandsHQ
+
+
+  - The `History` describing what caused the creation of a new `Version`
+    - Included description of the latest change
+
+
+  - The `Version` of a `Project` which had been generated into a PDF
+    - Included numbering of the version
+
+
+  - The author (`User`) of the project.
+
+<aside class='notice'>
+  <strong>Please Note</strong>:
+  <li>The URL of the PDF (as described in "links" => "content") is only valid for 48 hours.</li>
+  <li>This event may fire on occassion for the same version, in cases where a PDF is being regenerated (e.g. in the case of digital signatures)</li>
+</aside>

--- a/source/includes/event_subscriptions.md
+++ b/source/includes/event_subscriptions.md
@@ -25,7 +25,8 @@ curl https://api.handshq.com/v1/event_subscriptions \
 
 This endpoint allows you to be notified of certain events. Those currently supported are:
 
-- `version_pdf_created` - this is fired after we have generated and stored a PDF, which is now ready to be downloaded.
+- `version_pdf_created` - this is fired after we have generated and stored a project version PDF, which is now ready to be downloaded.
+
 <aside class="notice">
   Please note that the `version_pdf_created` event is scoped to look for subscriptions which were created by the same division that the project belongs to.
 </aside>

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -11,6 +11,7 @@ toc_footers:
 includes:
   - format
   - authentication
+  - event_subscriptions
   - projects
   - fields
   - errors

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -5,7 +5,7 @@ language_tabs: # must be one of https://git.io/vQNgJ
   - shell
 
 toc_footers:
-  - <a href='https://app.handshq.com/settings/api'>View your HandsHQ API settings</a>
+  - <a href='https://app.handshq.com/settings/api_configuration)'>View your HandsHQ API settings</a>
   - <a href='https://github.com/lord/slate'>Documentation Powered by Slate</a>
 
 includes:


### PR DESCRIPTION
- Upgraded dependencies to fix issue while deploying
- Updated examples to use https to avoid confusion on redirect status codes
- Added information on `EventSubscription` management
- Added information on payload of `verison_pdf_created` event