### PR TITLE
adding requirement of user_email to project creation

### DIFF
--- a/source/includes/_projects.md
+++ b/source/includes/_projects.md
@@ -14,6 +14,7 @@ curl https://api.handshq.com/v1/projects \
 
 ```json
   {
+    "user_email": "maddox@daystrom.com",
     "project": {
       "name": "My project with extra details",
       "fields_attributes": {
@@ -28,9 +29,15 @@ This endpoint allows you to create a project for the company who is registered w
 
 ### HTTP Request
 
-`POST https://api.handshq.com/v1/projects`
+`POST https://api.handshq.com/v1/projects?user_email=#{user_email}`
+
+### Required Query Parameters
+Parameter | Format | Required | Description
+--------- | ------ | -------- | -----------
+user_email | String | Yes | The email of the HandsHQ user who will be marked as the author of the project
 
 ### Allowed Project Parameters
+All parameters must be nested within `project`
 
 Parameter | Format | Required | Description
 --------- | ------ | -------- | -----------


### PR DESCRIPTION
- user_email was missing which is being used for actor context (would love to change this)
- Adding example based off this one in Postman:
```
{
	"user_email": "jody+tester@handshq.com",
	"project": {
	  "name": "My project with extra details",
	  "reference": "MP01",
	  "fields_attributes": {
	    "5": "My custom location of works"
		}
	}
}
```

![Screenshot 2021-11-23 at 16 40 38](https://user-images.githubusercontent.com/5759465/143066979-7b44653d-bd9c-49f9-a5c6-630581571cf2.png)
