### PR TITLE
adding clarification to personnel assigments create endpoint docs

### DIFF
--- a/source/includes/_personnel_assignments.md
+++ b/source/includes/_personnel_assignments.md
@@ -156,7 +156,7 @@ Once a personnel is added to a project, if reviews have been requested for that 
 ### Required Parameters
 Parameter | Format | Required | Description
 --------- | ------ | -------- | -----------
-user_email | String | Yes | The email of the HandsHQ user who will be marked as the requester of the generated review.
+user_email | String | Yes | The email of the HandsHQ user who will be marked as the requester of the generated review. The user in question must have access to the division that is registered with the API token you provide.
 
 
 ### Allowed Parameters


### PR DESCRIPTION
Clarifying that the user email param required for the personnel assignments create endpoint must belong to a user who has access to that division

<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->